### PR TITLE
Remove redundant navbar include from product list

### DIFF
--- a/listar_productos.php
+++ b/listar_productos.php
@@ -1,7 +1,6 @@
 <?php
 // Conexión a la base de datos
 require_once('conexion.php');
-include('navbar.php');
 
 // Consulta de productos
 $resultado = $conexion->query("SELECT * FROM productos");


### PR DESCRIPTION
## Summary
- Remove navbar inclusion from `listar_productos.php` so navigation is handled centrally.

## Testing
- `php -l listar_productos.php`
- `php -l index2.php`


------
https://chatgpt.com/codex/tasks/task_e_68abb9d0a9e08323b018685845260c60