### PR TITLE
Add price import feature with Excel/PDF support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/logs/*.log
+

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "fabrica_ba/app",
+    "description": "Aplicación Fabrica BA",
+    "license": "proprietary",
+    "require": {
+        "phpoffice/phpspreadsheet": "^1.29",
+        "smalot/pdfparser": "^1.0"
+    }
+}

--- a/importar_precios.php
+++ b/importar_precios.php
@@ -1,0 +1,125 @@
+<?php
+// Procesar importación
+$no_encontrados = $_SESSION['no_encontrados'] ?? [];
+unset($_SESSION['no_encontrados']);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['archivo'])) {
+    require __DIR__ . '/vendor/autoload.php';
+
+    $archivo = $_FILES['archivo'];
+    $tmp      = $archivo['tmp_name'];
+    $ext      = strtolower(pathinfo($archivo['name'], PATHINFO_EXTENSION));
+
+    $actualizados = 0;
+    $omitidos     = [];
+    $log_entries  = [];
+
+    if ($ext === 'xlsx') {
+        $spreadsheet = \PhpOffice\PhpSpreadsheet\IOFactory::load($tmp);
+        foreach ($spreadsheet->getActiveSheet()->toArray() as $fila) {
+            if (count($fila) < 2) {
+                continue;
+            }
+            $id    = trim($fila[0]);
+            if ($id === '' || preg_match('/^(id_producto|nombre)$/i', $id)) {
+                continue; // encabezado
+            }
+            $costo = trim($fila[1]);
+            $stock = isset($fila[2]) ? trim($fila[2]) : null;
+            procesar_producto($id, $costo, $stock, $actualizados, $omitidos, $log_entries, $conexion);
+        }
+    } elseif ($ext === 'pdf') {
+        $parser = new \Smalot\PdfParser\Parser();
+        $pdf    = $parser->parseFile($tmp);
+        $text   = $pdf->getText();
+        $lineas = explode("\n", $text);
+        foreach ($lineas as $linea) {
+            $partes = preg_split('/\s+/', trim($linea));
+            if (count($partes) < 2) {
+                continue;
+            }
+            $id    = $partes[0];
+            if (preg_match('/^(id_producto|nombre)$/i', $id)) {
+                continue;
+            }
+            $costo = $partes[1];
+            $stock = $partes[2] ?? null;
+            procesar_producto($id, $costo, $stock, $actualizados, $omitidos, $log_entries, $conexion);
+        }
+    } else {
+        $_SESSION['mensaje_toastr'] = 'Formato de archivo no permitido.';
+        $_SESSION['tipo_toastr']    = 'error';
+        header('Location: index2.php?vista=importar_precios');
+        exit;
+    }
+
+    if (!is_dir(__DIR__ . '/logs')) {
+        mkdir(__DIR__ . '/logs', 0777, true);
+    }
+    $log = '[' . date('Y-m-d H:i:s') . "\n" . implode("\n", $log_entries) . "\n";
+    file_put_contents(__DIR__ . '/logs/importar_precios.log', $log, FILE_APPEND);
+
+    $_SESSION['mensaje_toastr'] = "$actualizados productos actualizados, " . count($omitidos) . ' omitidos';
+    $_SESSION['tipo_toastr']    = 'success';
+    $_SESSION['no_encontrados'] = $omitidos;
+    header('Location: index2.php?vista=importar_precios');
+    exit;
+}
+
+function procesar_producto($id, $costo, $stock, &$actualizados, &$omitidos, &$log_entries, $conexion)
+{
+    $costo = (float) $costo;
+
+    if (is_numeric($id)) {
+        $stmt = $conexion->prepare('SELECT id_producto FROM productos WHERE id_producto=?');
+        $stmt->bind_param('i', $id);
+    } else {
+        $stmt = $conexion->prepare('SELECT id_producto FROM productos WHERE nombre=?');
+        $stmt->bind_param('s', $id);
+    }
+    $stmt->execute();
+    $stmt->bind_result($id_producto);
+    if ($stmt->fetch()) {
+        $stmt->close();
+        if ($stock !== null && $stock !== '') {
+            $stock = (int) $stock;
+            $upd = $conexion->prepare('UPDATE productos SET costo=?, stock=? WHERE id_producto=?');
+            $upd->bind_param('dii', $costo, $stock, $id_producto);
+        } else {
+            $upd = $conexion->prepare('UPDATE productos SET costo=? WHERE id_producto=?');
+            $upd->bind_param('di', $costo, $id_producto);
+        }
+        $upd->execute();
+        $upd->close();
+        $actualizados++;
+        $log_entries[] = "Actualizado: $id_producto | Costo: $costo" . ($stock !== null && $stock !== '' ? " | Stock: $stock" : '');
+    } else {
+        $omitidos[]   = $id;
+        $log_entries[] = "No encontrado: $id";
+        $stmt->close();
+    }
+}
+?>
+
+<div class="card">
+    <div class="card-body">
+        <h3 class="card-title">Importar Precios</h3>
+        <form method="post" enctype="multipart/form-data">
+            <div class="mb-3">
+                <input type="file" name="archivo" class="form-control" accept=".xlsx,.pdf" required>
+            </div>
+            <button type="submit" class="btn btn-primary">Importar</button>
+        </form>
+
+        <?php if (!empty($no_encontrados)): ?>
+            <div class="mt-3">
+                <h5>No encontrados:</h5>
+                <ul>
+                    <?php foreach ($no_encontrados as $ne): ?>
+                        <li><?= htmlspecialchars($ne) ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>

--- a/index2.php
+++ b/index2.php
@@ -82,6 +82,8 @@ $vista = $_GET['vista'] ?? 'listar_productos';
             include("usuarios.php");
         } elseif ($vista === 'editar_producto' && isset($_GET['id'])) {
             include("editar_producto.php");
+        } elseif ($vista === 'importar_precios') {
+            include("importar_precios.php");
         } else {
             include("listar_productos.php");
         }

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/navbar.php
+++ b/navbar.php
@@ -23,6 +23,11 @@
                         <i class="fas fa-users"></i> Usuarios
                     </a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link <?= ($vista === 'importar_precios') ? 'active' : '' ?>" href="index2.php?vista=importar_precios">
+                        <i class="fas fa-file-import"></i> Importar Precios
+                    </a>
+                </li>
             </ul>
 
             <!-- Usuario y cerrar sesión -->


### PR DESCRIPTION
## Summary
- configure Composer dependencies for spreadsheet and PDF parsing
- add Importar Precios view with upload form and processing logic
- link new view in navbar and router

## Testing
- `php -l importar_precios.php`
- `php -l navbar.php`
- `php -l index2.php`
- `composer validate`

> Note: `composer require phpoffice/phpspreadsheet smalot/pdfparser` failed with `CONNECT tunnel failed, response 403`; dependencies declared but not installed in this environment.


------
https://chatgpt.com/codex/tasks/task_e_68ace14bf68c8323a3975f8272f9935b